### PR TITLE
Refactor usage of process.env

### DIFF
--- a/src/pages/api/get-checkers.ts
+++ b/src/pages/api/get-checkers.ts
@@ -9,6 +9,6 @@ interface GetCheckersResponse {
 }
 
 export default async (_req: NextApiRequest, res: NextApiResponse<GetCheckersResponse>) => {
-  const data = isDevelopment() ? await testDataAsCheckerDTO() : await getAllEntries();
+  const data = isDevelopment ? await testDataAsCheckerDTO() : await getAllEntries();
   res.status(200).json({ checkers: data });
 };

--- a/src/pages/api/get-checkers.ts
+++ b/src/pages/api/get-checkers.ts
@@ -2,13 +2,13 @@ import { NextApiRequest, NextApiResponse } from 'next';
 import { getAllEntries } from '../../lib/firebase/actions';
 import { CheckerDTO } from '../../interfaces/Checker';
 import { testDataAsCheckerDTO } from '../../utils/testData/checkersTestData';
-import { Environment } from '../../interfaces/Environment';
+import { isDevelopment } from '../../utils/isEnvironment';
 
 interface GetCheckersResponse {
   checkers: CheckerDTO[];
 }
 
 export default async (_req: NextApiRequest, res: NextApiResponse<GetCheckersResponse>) => {
-  const data = process.env.NODE_ENV === Environment.Development ? await testDataAsCheckerDTO() : await getAllEntries();
+  const data = isDevelopment() ? await testDataAsCheckerDTO() : await getAllEntries();
   res.status(200).json({ checkers: data });
 };

--- a/src/utils/isEnvironment.ts
+++ b/src/utils/isEnvironment.ts
@@ -1,0 +1,9 @@
+import { Environment } from '../interfaces/Environment';
+
+const ENVIRONMENT = process.env.NODE_ENV;
+
+export const isDevelopment = () => ENVIRONMENT === Environment.Development;
+
+export const isProduction = () => ENVIRONMENT === Environment.Production;
+
+export const isTesting = () => ENVIRONMENT === Environment.Test;

--- a/src/utils/isEnvironment.ts
+++ b/src/utils/isEnvironment.ts
@@ -2,8 +2,8 @@ import { Environment } from '../interfaces/Environment';
 
 const ENVIRONMENT = process.env.NODE_ENV;
 
-export const isDevelopment = () => ENVIRONMENT === Environment.Development;
+export const isDevelopment = ENVIRONMENT === Environment.Development;
 
-export const isProduction = () => ENVIRONMENT === Environment.Production;
+export const isProduction = ENVIRONMENT === Environment.Production;
 
-export const isTesting = () => ENVIRONMENT === Environment.Test;
+export const isTesting = ENVIRONMENT === Environment.Test;

--- a/src/utils/validApiKey.ts
+++ b/src/utils/validApiKey.ts
@@ -1,2 +1,3 @@
-export const validFirebaseApiKey = (key: string | string[]): boolean =>
-  key ? key === process.env.FIREBASE_API_KEY : false;
+import { firebaseConfig } from '../lib/firebase/config';
+
+export const validFirebaseApiKey = (key: string | string[]): boolean => (key ? key === firebaseConfig.apiKey : false);


### PR DESCRIPTION
This PR refactors usage of `process.env` by doing:
* Moving API key check against config object instead of process.env
* Move environment check to `isEnvironment.ts` utils 