### PR TITLE
Add api middlewares

### DIFF
--- a/src/middlewares/authorizationMiddleware.ts
+++ b/src/middlewares/authorizationMiddleware.ts
@@ -1,0 +1,9 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { validFirebaseApiKey } from '../utils/validApiKey';
+
+export const withAuthorization = (handler: Function) => (req: NextApiRequest, res: NextApiResponse) => {
+  if (!validFirebaseApiKey(req.query.apiKey)) {
+    return res.status(403).json({ message: 'This route requiers authorization' });
+  }
+  return handler(req, res);
+};

--- a/src/middlewares/todayAlreadyScrapedMiddleware.ts
+++ b/src/middlewares/todayAlreadyScrapedMiddleware.ts
@@ -1,0 +1,19 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { getLatestEntry } from '../lib/firebase/actions';
+import { isToday } from 'date-fns';
+import { CheckerDTO } from '../interfaces/Checker';
+
+const isTodaysCheckersLogged = (latestChecker: CheckerDTO) => latestChecker && isToday(new Date(latestChecker.created));
+
+export const withTodayAlreadyScraped = (handler: Function) => async (req: NextApiRequest, res: NextApiResponse) => {
+  try {
+    const latestChecker = await getLatestEntry();
+    if (isTodaysCheckersLogged(latestChecker)) {
+      return res.status(200).json({ message: `Today's checkers has already been added into db` });
+    }
+    return handler(req, res);
+  } catch (error) {
+    console.log(`Error when checking if todays amount of checkers has been added.`, error);
+    res.status(500).json({ message: error });
+  }
+};

--- a/src/pages/api/seed/add-all.ts
+++ b/src/pages/api/seed/add-all.ts
@@ -1,18 +1,16 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { seedDBWithTestdata } from '../../../lib/firebase/seedTestdata';
-import { validFirebaseApiKey } from '../../../utils/validApiKey';
+import { withAuthorization } from '../../../middlewares/authorizationMiddleware';
 
-export default async (req: NextApiRequest, res: NextApiResponse) => {
-  if (validFirebaseApiKey(req.query.apiKey)) {
-    try {
-      const fullSeed = req.query.fullSeed === 'true';
-      await seedDBWithTestdata(fullSeed);
-      res.status(200).json({ status: 200, message: 'Firebase db has been successfully seeded' });
-    } catch (error) {
-      console.log('Error when seeding db', error);
-      res.status(500).json({ status: 500, message: error });
-    }
-  } else {
-    res.status(404).json({ status: 401 });
+const requestHandler = async (req: NextApiRequest, res: NextApiResponse) => {
+  try {
+    const fullSeed = req.query.fullSeed === 'true';
+    await seedDBWithTestdata(fullSeed);
+    res.status(200).json({ status: 200, message: 'Firebase db has been successfully seeded' });
+  } catch (error) {
+    console.log('Error when seeding db', error);
+    res.status(500).json({ status: 500, message: error });
   }
 };
+
+export default withAuthorization(requestHandler);

--- a/src/pages/api/seed/add-today.ts
+++ b/src/pages/api/seed/add-today.ts
@@ -1,18 +1,12 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { scrapeForCurrentCheckers } from '../../../lib/scraping/scraper';
 import { getCurrentDate } from '../../../utils/getCurrentDate';
-import { addEntryToDB, getLatestEntry } from '../../../lib/firebase/actions';
+import { addEntryToDB } from '../../../lib/firebase/actions';
 import { FirebaseChecker } from '../../../interfaces/Checker';
-import { isToday } from '../../../utils/isToday';
+import { withTodayAlreadyScraped } from '../../../middlewares/todayAlreadyScrapedMiddleware';
 
-export default async (req: NextApiRequest, res: NextApiResponse) => {
+const requestHandler = async (_req: NextApiRequest, res: NextApiResponse) => {
   try {
-    const currentEntryForToday = await getLatestEntry();
-    if (currentEntryForToday && isToday(new Date(currentEntryForToday.created))) {
-      res.status(200).json({ status: 200, message: `Today's checkers has already been added into db` });
-      return;
-    }
-
     const currentCheckers = await scrapeForCurrentCheckers();
     const checkerObj = {
       amount: currentCheckers,
@@ -25,3 +19,5 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
     res.status(500).json({ status: 500, message: error });
   }
 };
+
+export default withTodayAlreadyScraped(requestHandler);

--- a/src/pages/api/seed/delete-all.ts
+++ b/src/pages/api/seed/delete-all.ts
@@ -1,8 +1,9 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { deleteAllEntriesFromDB } from '../../../lib/firebase/actions';
 import { validFirebaseApiKey } from '../../../utils/validApiKey';
+import { withAuthorization } from '../../../middlewares/authorizationMiddleware';
 
-export default async (req: NextApiRequest, res: NextApiResponse) => {
+const requestHandler = async (req: NextApiRequest, res: NextApiResponse) => {
   if (validFirebaseApiKey(req.query.apiKey)) {
     try {
       await deleteAllEntriesFromDB();
@@ -15,3 +16,5 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
     res.status(404).json({ status: 401 });
   }
 };
+
+export default withAuthorization(requestHandler);


### PR DESCRIPTION
This PR adds api middlewares for:
* API key requirement as query param for seed routes
* Checking if today is already seeded for route that is cron curled every day (to not add data for same day twice)

Middlewares for next api routes can be implemented in different ways - this one is a easy and straight forward way using higher order functions to wrap exported route functions inside api folder. 
